### PR TITLE
New feature: Add RMPP colour selection on RM1 and RM2

### DIFF
--- a/0.0.11-pre2/rmHacks/more_colors_hack.qmd
+++ b/0.0.11-pre2/rmHacks/more_colors_hack.qmd
@@ -1,0 +1,36 @@
+SLOT rmhConfigProperties
+    INSERT {
+        property bool rmhEnableMoreColorsHack: ~&6504329801&~
+    }
+END SLOT
+
+SLOT rmhConfigAliases
+    INSERT {
+        property alias rmhEnableMoreColorsHack: ~&7083272960857&~.rmhEnableMoreColorsHack
+    }
+END SLOT
+
+SLOT rmhSettingsToolbarModel
+    INSERT {
+        {
+           ~&214632764553&~: "More colors",
+           ~&478136262235079021&~: "Enable all the colors from the reMarkable Paper Pro on the reMarkable 1 or 2",
+           ~&233723734822480&~: ~&7082020628281&~.rmhEnableMoreColorsHack,
+           ~&7082453764199&~: () => { ~&7082020628281&~.rmhEnableMoreColorsHack = !~&7082020628281&~.rmhEnableMoreColorsHack },
+        },
+    }
+END SLOT
+
+AFFECT [[2850686855228789517]] 
+IMPORT [[7082546018834]] 1.0
+	TRAVERSE [[454089850271038938]]#[[6504254477]] > [[7708106203292350108]]
+		REPLACE [[14419969282314418184]] WITH 
+			{
+			~&14419969282314418184&~: !(~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.RM110 || ~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.~&214601156697&~) || ~&7082020628281&~.rmhEnableMoreColorsHack 
+			}
+	END TRAVERSE
+END AFFECT
+
+
+
+

--- a/0.0.11-pre2/rmHacks/more_colors_hack.qmd
+++ b/0.0.11-pre2/rmHacks/more_colors_hack.qmd
@@ -1,12 +1,12 @@
 SLOT rmhConfigProperties
     INSERT {
-        property bool rmhEnableMoreColorsHack: ~&6504329801&~
+        property bool rmhMoreColorsHack: ~&6504329801&~
     }
 END SLOT
 
 SLOT rmhConfigAliases
     INSERT {
-        property alias rmhEnableMoreColorsHack: ~&7083272960857&~.rmhEnableMoreColorsHack
+        property alias rmhMoreColorsHack: ~&7083272960857&~.rmhMoreColorsHack
     }
 END SLOT
 
@@ -15,8 +15,8 @@ SLOT rmhSettingsToolbarModel
         {
            ~&214632764553&~: "More colors",
            ~&478136262235079021&~: "Enable all the colors from the reMarkable Paper Pro on the reMarkable 1 or 2",
-           ~&233723734822480&~: ~&7082020628281&~.rmhEnableMoreColorsHack,
-           ~&7082453764199&~: () => { ~&7082020628281&~.rmhEnableMoreColorsHack = !~&7082020628281&~.rmhEnableMoreColorsHack },
+           ~&233723734822480&~: ~&7082020628281&~.rmhMoreColorsHack,
+           ~&7082453764199&~: () => { ~&7082020628281&~.rmhMoreColorsHack = !~&7082020628281&~.rmhMoreColorsHack },
         },
     }
 END SLOT
@@ -26,7 +26,7 @@ IMPORT [[7082546018834]] 1.0
 	TRAVERSE [[454089850271038938]]#[[6504254477]] > [[7708106203292350108]]
 		REPLACE [[14419969282314418184]] WITH 
 			{
-			~&14419969282314418184&~: !(~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.RM110 || ~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.~&214601156697&~) || ~&7082020628281&~.rmhEnableMoreColorsHack 
+			~&14419969282314418184&~: !(~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.RM110 || ~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.~&214601156697&~) || ~&7082020628281&~.rmhMoreColorsHack 
 			}
 	END TRAVERSE
 END AFFECT

--- a/0.0.11-pre2/zz_rmhacks.qmd
+++ b/0.0.11-pre2/zz_rmhacks.qmd
@@ -18,6 +18,7 @@ LOAD rmHacks/force_refresh_gesture_hack.qmd
 LOAD rmHacks/bookmarks.qmd
 LOAD rmHacks/last_document_gesture_hack.qmd
 LOAD rmHacks/more_stroke_sizes_hack.qmd
+LOAD rmHacks/more_colors_hack.qmd
 LOAD rmHacks/document_battery_wifi_hack.qmd
 LOAD rmHacks/share_tool_toggle_wifi_hack.qmd
 LOAD rmHacks/share_tool_toggle_all_gestures_hack.qmd


### PR DESCRIPTION
Add a toggle to the Toolbar section for enabling the colour selection from the RMPP on RM1 and RM2

Currently does nothing on RMPP, but could also be enabled there, to allow to turn the extra colours off

(Just remove `!(~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.RM110 || ~&8397887615021556741&~.~&8399372782522826843&~ === ~&8397887615021556741&~.~&214601156697&~) ||` from line 29.)

Should probably eventually be hidden in settings on the RMPP, unless the above approach is taken).